### PR TITLE
Implement generic linked list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The "eXtra C Framework" includes a set of commonly used data structures and func
 - Dynamic generic array implementation (`xArray.h`)
 - Deferrable function calls module (`xDefer.h`)
 - Mathematical matrix operations module (`xMatrix.h`)
+- Dynamic generic linked list implementation (`xList.h`)
 ### Listed modules are tested and ready for use in projects
 
 ## Experimental modules (lacking tests, documentation or are incomplete):
-- Dynamic generic linked list implementation (`xList.h`)
 - Dynamic generic treemap implementation (`xDictionary.h`)
 - Dynamic generic stack implementation (`xStack.h`)
 - Dynamic generic queue implementation (`xQueue.h`)

--- a/include/xStructures/xList.h
+++ b/include/xStructures/xList.h
@@ -1,0 +1,219 @@
+/**
+ * @file xList.h
+ * @author 0xDontCare (https://github.com/0xDontCare)
+ * @brief Linked list implemenation in xStructures module.
+ * @version 0.10
+ * @date 26.07.2024.
+ *
+ * Module declares linked list structure and functions for interaction with it. All functions have prefix `xList_`.
+ */
+
+#ifndef XSTRUCTURES_LIST_H
+#define XSTRUCTURES_LIST_H
+
+#include "xBase/xTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief
+ * Linked list structure introduced by xcFramework.
+ *
+ * @note
+ * Do not access structure members directly. Use provided functions for managing xList object.
+ *
+ * @warning
+ * Even if structure itself is on stack, it should be properly freed using xList_free() function to free internal data.
+ */
+typedef struct xList_s xList;
+
+/**
+ * @brief
+ * Creates empty xList object.
+ *
+ * @param elemSize Size of single element in bytes.
+ * @return xList object with no data.
+ *
+ * @note
+ * If function fails to allocate memory, returned object will be invalid to use. You can use xList_isValid() to check if object is
+ * valid.
+ */
+xList xList_new(xSize elemSize);
+
+/**
+ * @brief
+ * Free xList object and its data from memory.
+ *
+ * @param list Pointer to xList object to free.
+ *
+ * @note
+ * Once xList object is freed, it is invalidated and no longer usable with other functions.
+ *
+ * @warning
+ * User is responsible for freeing individual elements if they are dynamically allocated.
+ */
+void xList_free(xList *list);
+
+/**
+ * @brief
+ * Get number of elements in list.
+ *
+ * @param list Pointer to xList object.
+ * @return xSize Number of elements in list.
+ */
+inline xSize xList_getSize(const xList *list);
+
+/**
+ * @brief
+ * Get size of single element in list in bytes.
+ *
+ * @param list Pointer to xList object.
+ * @return xSize Size of single element in list in bytes.
+ */
+inline xSize xList_getElemSize(const xList *list);
+
+/**
+ * @brief
+ * Check if xList object is valid.
+ *
+ * @param list Pointer to xList object.
+ * @return xBool Non-zero if object is valid, zero otherwise.
+ */
+inline xBool xList_isValid(const xList *list);
+
+/**
+ * @brief
+ * Insert element at specified index in list.
+ *
+ * @param list Pointer to the list object.
+ * @param data Pointer to data to insert.
+ * @param index Index to insert data at.
+ *
+ * @note
+ * If index is greater than list size, function will do nothing and return.
+ */
+void xList_insert(xList *list, const void *data, xSize index);
+
+/**
+ * @brief
+ * Get element at specified index in list.
+ *
+ * @param list Pointer to the list object.
+ * @param index Index of element to get.
+ * @return void* Pointer to element at specified index.
+ *
+ * @note
+ * If index is greater than list size, function will return NULL.
+ */
+void *xList_get(const xList *list, xSize index);
+
+/**
+ * @brief
+ * Remove element at specified index in list.
+ *
+ * @param list Pointer to the list object.
+ * @param index Index of element to remove.
+ * @return void* Pointer to removed element.
+ *
+ * @note
+ * If index is greater than list size, function will return NULL and do nothing.
+ *
+ * @warning
+ * User is responsible for freeing removed element if it is dynamically allocated.
+ *
+ */
+void *xList_remove(xList *list, xSize index);
+
+/**
+ * @brief
+ * Push element to the front of the list.
+ *
+ * @param list Pointer to the list object.
+ * @param data Pointer to data to push to front of the list.
+ */
+void xList_pushFront(xList *list, const void *data);
+
+/**
+ * @brief
+ * Push element to the back of the list.
+ *
+ * @param list Pointer to the list object.
+ * @param data Pointer to data to push to back of the list.
+ */
+void xList_pushBack(xList *list, const void *data);
+
+/**
+ * @brief
+ * Pop element from the front of the list.
+ *
+ * @param list Pointer to the list object.
+ * @return void* Pointer to popped element.
+ *
+ * @note
+ * If list is empty, function will return NULL.
+ *
+ * @warning
+ * Caller is responsible for freeing popped element if it is dynamically allocated.
+ */
+void *xList_popFront(xList *list);
+
+/**
+ * @brief
+ * Pop element from the back of the list.
+ *
+ * @param list Pointer to the list object.
+ * @return void* Pointer to popped element.
+ *
+ * @note
+ * If list is empty, function will return NULL.
+ */
+void *xList_popBack(xList *list);
+
+/**
+ * @brief
+ * Peek element from the front of the list.
+ *
+ * @param list Pointer to the list object.
+ * @return void* Pointer to peeked element.
+ *
+ * @note
+ * If list is empty, function will return NULL.
+ *
+ * @warning
+ * Element is not removed from the list so it is unsafe to modify or free it.
+ */
+void *xList_peekFront(const xList *list);
+
+/**
+ * @brief
+ * Peek element from the back of the list.
+ *
+ * @param list Pointer to the list object.
+ * @return void* Pointer to peeked element.
+ *
+ * @note
+ * If list is empty, function will return NULL.
+ *
+ * @warning
+ * Element is not removed from the list so it is unsafe to modify or free it.
+ */
+void *xList_peekBack(const xList *list);
+
+/**
+ * @brief
+ * Clear list by removing all elements.
+ *
+ * @param list Pointer to the list object.
+ *
+ * @warning
+ * User is responsible for freeing individual elements if they are dynamically allocated.
+ */
+void xList_clear(xList *list);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XSTRUCTURES_LIST_H

--- a/include/xStructures/xList.h
+++ b/include/xStructures/xList.h
@@ -51,8 +51,8 @@ xList *xList_new(xSize elemSize);
  * @note
  * Once xList object is freed, it is invalidated and no longer usable with other functions.
  *
- * @warning
- * User is responsible for freeing individual elements if they are dynamically allocated.
+ * @note
+ * All elements in the list are freed as well. If they contain other dynamically allocated data, it should be freed by user before.
  */
 void xList_free(xList *list);
 
@@ -106,6 +106,9 @@ void xList_insert(xList *list, const void *data, xSize index);
  *
  * @note
  * If index is greater than list size, function will return NULL.
+ *
+ * @warning
+ * Element should not be freed as returned address is not its base address. Trying to do so will result in undefined behavior.
  */
 void *xList_get(const xList *list, xSize index);
 
@@ -121,7 +124,7 @@ void *xList_get(const xList *list, xSize index);
  * If index is greater than list size, function will return NULL and do nothing.
  *
  * @warning
- * User is responsible for freeing removed element if it is dynamically allocated.
+ * User is responsible for freeing returned element.
  *
  */
 void *xList_remove(xList *list, xSize index);
@@ -155,7 +158,7 @@ void xList_pushBack(xList *list, const void *data);
  * If list is empty, function will return NULL.
  *
  * @warning
- * Caller is responsible for freeing popped element if it is dynamically allocated.
+ * Caller is responsible for freeing popped element.
  */
 void *xList_popFront(xList *list);
 
@@ -168,6 +171,9 @@ void *xList_popFront(xList *list);
  *
  * @note
  * If list is empty, function will return NULL.
+ *
+ * @warning
+ * Caller is responsible for freeing popped element.
  */
 void *xList_popBack(xList *list);
 
@@ -182,7 +188,7 @@ void *xList_popBack(xList *list);
  * If list is empty, function will return NULL.
  *
  * @warning
- * Element is not removed from the list so it is unsafe to modify or free it.
+ * Returned address is not base address of the element so it should not be freed. Trying to do so will result in undefined behavior.
  */
 void *xList_peekFront(const xList *list);
 
@@ -197,7 +203,7 @@ void *xList_peekFront(const xList *list);
  * If list is empty, function will return NULL.
  *
  * @warning
- * Element is not removed from the list so it is unsafe to modify or free it.
+ * Returned address is not base address of the element so it should not be freed. Trying to do so will result in undefined behavior.
  */
 void *xList_peekBack(const xList *list);
 
@@ -207,8 +213,8 @@ void *xList_peekBack(const xList *list);
  *
  * @param list Pointer to the list object.
  *
- * @warning
- * User is responsible for freeing individual elements if they are dynamically allocated.
+ * @note
+ * If elements contain dynamically allocated data, it should be freed by user before calling this function.
  */
 void xList_clear(xList *list);
 

--- a/include/xStructures/xList.h
+++ b/include/xStructures/xList.h
@@ -34,13 +34,13 @@ typedef struct xList_s xList;
  * Creates empty xList object.
  *
  * @param elemSize Size of single element in bytes.
- * @return xList object with no data.
+ * @return Pointer to xList object with no data.
  *
  * @note
- * If function fails to allocate memory, returned object will be invalid to use. You can use xList_isValid() to check if object is
- * valid.
+ * If function fails to allocate memory or `elemSize` is zero, returned object will be invalid to use. You can use xList_isValid()
+ * to check if created object is valid.
  */
-xList xList_new(xSize elemSize);
+xList *xList_new(xSize elemSize);
 
 /**
  * @brief
@@ -63,7 +63,7 @@ void xList_free(xList *list);
  * @param list Pointer to xList object.
  * @return xSize Number of elements in list.
  */
-inline xSize xList_getSize(const xList *list);
+extern xSize xList_getSize(const xList *list);
 
 /**
  * @brief
@@ -72,7 +72,7 @@ inline xSize xList_getSize(const xList *list);
  * @param list Pointer to xList object.
  * @return xSize Size of single element in list in bytes.
  */
-inline xSize xList_getElemSize(const xList *list);
+extern xSize xList_getElemSize(const xList *list);
 
 /**
  * @brief
@@ -81,7 +81,7 @@ inline xSize xList_getElemSize(const xList *list);
  * @param list Pointer to xList object.
  * @return xBool Non-zero if object is valid, zero otherwise.
  */
-inline xBool xList_isValid(const xList *list);
+extern xBool xList_isValid(const xList *list);
 
 /**
  * @brief

--- a/src/xStructures/xList.c
+++ b/src/xStructures/xList.c
@@ -1,0 +1,285 @@
+#include "xStructures/xList.h"
+#include <stdlib.h>  // standard library (for malloc, free)
+#include "xBase/xTypes.h"
+
+// TODO: remove dependency on stdlib.h (custom memory allocation functions)
+
+typedef struct xListNode_s {
+    void *data;
+    struct xListNode_s *next;
+    struct xListNode_s *prev;
+} xListNode;
+
+struct xList_s {
+    xListNode *head;
+    xListNode *tail;
+    xSize elemSize;
+    xSize listSize;
+};
+
+xList xList_new(xSize elemSize)
+{
+    // validate arguments
+    if (elemSize == 0) {
+        return (xList){0};
+    }
+
+    xList list = {0};
+    list.elemSize = elemSize;
+    return list;
+}
+
+void xList_free(xList *list)
+{
+    if (!list || !list->head) {
+        return;
+    }
+
+    xListNode *current = list->head;
+    while (current) {
+        xListNode *next = current->next;
+        free(current);
+        current = next;
+    }
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->listSize = 0;
+    list->elemSize = 0;
+}
+
+inline xSize xList_getSize(const xList *list) { return (list) ? list->listSize : 0; }
+
+inline xSize xList_getElemSize(const xList *list) { return (list) ? list->elemSize : 0; }
+
+inline xBool xList_isValid(const xList *list) { return (list && list->elemSize > 0) ? true : false; }
+
+void xList_insert(xList *list, const void *data, xSize index)
+{
+    // validate arguments
+    if (!list || !data || index > list->listSize) {
+        return;
+    }
+
+    // special cases for start and end of the list
+    if (index == 0) {
+        // start of the list
+        xList_pushFront(list, data);
+        return;
+    } else if (index == list->listSize) {
+        // end of the list
+        xList_pushBack(list, data);
+        return;
+    }
+
+    // allocate memory for new node
+    xListNode *newNode = (xListNode *)malloc(sizeof(xListNode));
+    if (!newNode) {
+        return;
+    }
+
+    // assign data to the new node
+    newNode->data = (void *)data;
+
+    // somewhere in the middle of the list
+    xListNode *current = list->head;
+    for (xSize i = 0; i < index; i++) {
+        current = current->next;
+    }
+    newNode->next = current;
+    newNode->prev = current->prev;
+    current->prev->next = newNode;
+    current->prev = newNode;
+    list->listSize++;
+}
+
+void *xList_get(const xList *list, xSize index)
+{
+    // validate arguments
+    if (!list || index >= list->listSize) {
+        return NULL;
+    }
+
+    // find node at specified index
+    xListNode *current = list->head;
+    for (xSize i = 0; i < index; i++) {
+        current = current->next;
+    }
+
+    return current->data;
+}
+
+void *xList_remove(xList *list, xSize index)
+{
+    // validate arguments
+    if (!list || index >= list->listSize) {
+        return NULL;
+    }
+
+    // find node at specified index
+    xListNode *current = list->head;
+    for (xSize i = 0; i < index; i++) {
+        current = current->next;
+    }
+
+    // remove node from the list
+    if (current->prev) {
+        current->prev->next = current->next;
+    } else {
+        list->head = current->next;
+    }
+    if (current->next) {
+        current->next->prev = current->prev;
+    } else {
+        list->tail = current->prev;
+    }
+
+    // save data and free memory
+    void *data = current->data;
+    free(current);
+    list->listSize--;
+
+    return data;
+}
+
+void xList_pushFront(xList *list, const void *data)
+{
+    // validate arguments
+    if (!list || !data) {
+        return;
+    }
+
+    // allocate memory for new node
+    xListNode *newNode = (xListNode *)malloc(sizeof(xListNode));
+    if (!newNode) {
+        return;
+    }
+
+    // assign data to the new node
+    newNode->data = (void *)data;
+
+    // insert node into the list
+    newNode->next = list->head;
+    if (list->head) {
+        list->head->prev = newNode;
+    } else {
+        list->tail = newNode;
+    }
+    newNode->prev = NULL;
+    list->head = newNode;
+    list->listSize++;
+}
+
+void xList_pushBack(xList *list, const void *data)
+{
+    // validate arguments
+    if (!list || !data) {
+        return;
+    }
+
+    // allocate memory for new node
+    xListNode *newNode = (xListNode *)malloc(sizeof(xListNode));
+    if (!newNode) {
+        return;
+    }
+
+    // assign data to the new node
+    newNode->data = (void *)data;
+
+    // insert node into the list
+    newNode->next = NULL;
+    newNode->prev = list->tail;
+    if (list->tail) {
+        list->tail->next = newNode;
+    } else {
+        list->head = newNode;
+    }
+    list->tail = newNode;
+    list->listSize++;
+}
+
+void *xList_popFront(xList *list)
+{
+    // validate arguments
+    if (!list || !list->head) {
+        return NULL;
+    }
+
+    // remove node from the list
+    xListNode *current = list->head;
+    list->head = current->next;
+    if (list->head) {
+        list->head->prev = NULL;
+    } else {
+        list->tail = NULL;
+    }
+
+    // save data and free memory
+    void *data = current->data;
+    free(current);
+    list->listSize--;
+
+    return data;
+}
+
+void *xList_popBack(xList *list)
+{
+    // validate arguments
+    if (!list || !list->tail) {
+        return NULL;
+    }
+
+    // remove node from the list
+    xListNode *current = list->tail;
+    list->tail = current->prev;
+    if (list->tail) {
+        list->tail->next = NULL;
+    } else {
+        list->head = NULL;
+    }
+
+    // save data and free memory
+    void *data = current->data;
+    free(current);
+    list->listSize--;
+
+    return data;
+}
+
+void *xList_peekFront(const xList *list)
+{
+    // validate arguments
+    if (!list || !list->head) {
+        return NULL;
+    }
+
+    return list->head->data;
+}
+
+void *xList_peekBack(const xList *list)
+{
+    // validate arguments
+    if (!list || !list->tail) {
+        return NULL;
+    }
+
+    return list->tail->data;
+}
+
+void xList_clear(xList *list)
+{
+    if (!list) {
+        return;
+    }
+
+    xListNode *current = list->head;
+    while (current) {
+        xListNode *next = current->next;
+        free(current);
+        current = next;
+    }
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->listSize = 0;
+}

--- a/src/xStructures/xList.c
+++ b/src/xStructures/xList.c
@@ -17,24 +17,35 @@ struct xList_s {
     xSize listSize;
 };
 
-xList xList_new(xSize elemSize)
+xList *xList_new(xSize elemSize)
 {
     // validate arguments
     if (elemSize == 0) {
-        return (xList){0};
+        return NULL;
     }
 
-    xList list = {0};
-    list.elemSize = elemSize;
+    // allocate memory for the list
+    xList *list = (xList *)malloc(sizeof(xList));
+    if (!list) {
+        return NULL;
+    }
+
+    // initialize list attributes
+    list->elemSize = elemSize;
+    list->listSize = 0;
+    list->head = NULL;
+    list->tail = NULL;
     return list;
 }
 
 void xList_free(xList *list)
 {
-    if (!list || !list->head) {
+    // validate arguments
+    if (!list) {
         return;
     }
 
+    // free all nodes in the list
     xListNode *current = list->head;
     while (current) {
         xListNode *next = current->next;
@@ -42,10 +53,11 @@ void xList_free(xList *list)
         current = next;
     }
 
+    // make nodes inaccessible and free list descriptor
     list->head = NULL;
     list->tail = NULL;
-    list->listSize = 0;
-    list->elemSize = 0;
+
+    free(list);
 }
 
 inline xSize xList_getSize(const xList *list) { return (list) ? list->listSize : 0; }
@@ -114,6 +126,15 @@ void *xList_remove(xList *list, xSize index)
     // validate arguments
     if (!list || index >= list->listSize) {
         return NULL;
+    }
+
+    // special cases for start and end of the list
+    if (index == 0) {
+        // start of the list
+        return xList_popFront(list);
+    } else if (index == list->listSize - 1) {
+        // end of the list
+        return xList_popBack(list);
     }
 
     // find node at specified index

--- a/tests/xList_test.c
+++ b/tests/xList_test.c
@@ -1,0 +1,377 @@
+/**
+ * @file xList_test.c
+ * @author 0xDontCare (https://github.com/0xDontCare)
+ * @brief CUnit test for xList module.
+ * @version 0.1
+ * @date 16.09.2024.
+ */
+
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
+#include <CUnit/TestDB.h>
+#include <malloc.h>
+#include "xBase/xTypes.h"
+#include "xStructures/xList.h"
+
+void test_xList_new(void)
+{
+    xList *list = NULL;
+
+    // Test case 1: Valid list element size
+    list = xList_new(sizeof(xUInt32));
+    CU_ASSERT_PTR_NOT_NULL(list);
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+    CU_ASSERT_EQUAL(xList_getElemSize(list), sizeof(xUInt32));
+    CU_ASSERT_EQUAL(xList_isValid(list), true);
+    xList_free(list);
+
+    // Test case 2: Invalid list element size
+    list = xList_new(0);  // should return NULL
+    CU_ASSERT_PTR_NULL(list);
+}
+
+void test_xList_free(void)
+{
+    // this test chould be analyzed through debugger and valgrind
+
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Valid list
+    xList_free(list);
+
+    // Test case 2: NULL list
+    xList_free(NULL);  // should not crash
+}
+
+void test_xList_getters(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Get size of empty list
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+
+    // Test case 2: Get element size of list
+    CU_ASSERT_EQUAL(xList_getElemSize(list), sizeof(xUInt32));
+
+    // Test case 3: Get NULL list size
+    CU_ASSERT_EQUAL(xList_getSize(NULL), 0)
+
+    // Test case 4: Get NULL list element size
+    CU_ASSERT_EQUAL(xList_getElemSize(NULL), 0)
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_pushFront(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Push element to empty list
+    xUInt32 value = 0x12345678;
+    xList_pushFront(list, &value);
+    CU_ASSERT_EQUAL(xList_getSize(list), 1);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), value);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), value);
+
+    // Test case 2: Push element to non-empty list
+    value = 0x9ABCDEF0;
+    xList_pushFront(list, &value);
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), value);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), 0x12345678);
+
+    // Test case 3: Push element to NULL list
+    xList_pushFront(NULL, &value);  // should not crash
+
+    // Test case 4: Push NULL element to list
+    xList_pushFront(list, NULL);              // should not crash
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);  // nothing should change
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_pushBack(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Push element to empty list
+    xUInt32 value = 0x12345678;
+    xList_pushBack(list, &value);
+    CU_ASSERT_EQUAL(xList_getSize(list), 1);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), value);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), value);
+
+    // Test case 2: Push element to non-empty list
+    value = 0x9ABCDEF0;
+    xList_pushBack(list, &value);
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), 0x12345678);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), value);
+
+    // Test case 3: Push element to NULL list
+    xList_pushBack(NULL, &value);  // should not crash
+
+    // Test case 4: Push NULL element to list
+    xList_pushBack(list, NULL);               // should not crash
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);  // nothing should change
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_insert(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Insert element to empty list
+    xUInt32 value = 0x12345678;
+    xList_insert(list, &value, 0);
+    CU_ASSERT_EQUAL(xList_getSize(list), 1);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), value);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), value);
+
+    // Test case 2: Insert element to non-empty list
+    value = 0x9ABCDEF0;
+    xList_insert(list, &value, 1);
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), 0x12345678);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), value);
+
+    // Test case 3: Insert element to NULL list
+    xList_insert(NULL, &value, 0);  // should not crash
+
+    // Test case 4: Insert NULL element to list
+    xList_insert(list, NULL, 0);              // should not crash
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);  // nothing should change
+
+    // Test case 5: Insert element at invalid index
+    xList_insert(list, &value, 3);            // should not crash
+    CU_ASSERT_EQUAL(xList_getSize(list), 2);  // nothing should change
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_peekFront(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Peek element from empty list
+    CU_ASSERT_EQUAL(xList_peekFront(list), NULL);
+
+    // Test case 2: Peek element from non-empty list
+    xList_pushBack(list, &values[0]);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), values[0]);
+
+    // Test case 3: Peek element from list witn many elements
+    for (xSize i = 1; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekFront(list), values[0]);
+
+    // Test case 3: Peek element from NULL list
+    CU_ASSERT_PTR_NULL(xList_peekFront(NULL));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_peekBack(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Peek element from empty list
+    CU_ASSERT_EQUAL(xList_peekBack(list), NULL);
+
+    // Test case 2: Peek element from non-empty list
+    xList_pushBack(list, &values[0]);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), values[0]);
+
+    // Test case 3: Peek element from list witn many elements
+    for (xSize i = 1; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_peekBack(list), values[4]);
+
+    // Test case 3: Peek element from NULL list
+    CU_ASSERT_PTR_NULL(xList_peekBack(NULL));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_get(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Get element from empty list
+    CU_ASSERT_EQUAL(xList_get(list, 0), NULL);
+
+    // Test case 2: Get element from non-empty list
+    xList_pushBack(list, &values[0]);
+    CU_ASSERT_EQUAL(*(xUInt32 *)xList_get(list, 0), values[0]);
+
+    // Test case 3: Get element from list witn many elements
+    for (xSize i = 1; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    for (xSize i = 0; i < 5; i++) {
+        CU_ASSERT_EQUAL(*(xUInt32 *)xList_get(list, i), values[i]);
+    }
+
+    // Test case 3: Get element from NULL list
+    CU_ASSERT_PTR_NULL(xList_get(NULL, 0));
+
+    // Test case 4: Get element at invalid index
+    CU_ASSERT_PTR_NULL(xList_get(list, 5));
+    CU_ASSERT_PTR_NULL(xList_get(list, 15));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_popFront(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Pop element from empty list
+    CU_ASSERT_PTR_NULL(xList_popFront(list));
+
+    // Test case 2: Pop element from non-empty list
+    for (xSize i = 0; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    for (xSize i = 0; i < 5; i++) {
+        xUInt32 *popped = xList_popFront(list);
+        CU_ASSERT_EQUAL(*popped, values[i]);
+        free(popped);
+    }
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+
+    // Test case 3: Pop element from NULL list
+    CU_ASSERT_PTR_NULL(xList_popFront(NULL));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_popBack(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Pop element from empty list
+    CU_ASSERT_PTR_NULL(xList_popBack(list));
+
+    // Test case 2: Pop element from non-empty list
+    for (xSize i = 0; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    for (xSize i = 0; i < 5; i++) {
+        xUInt32 *popped = xList_popBack(list);
+        CU_ASSERT_EQUAL(*popped, values[4 - i]);
+        free(popped);
+    }
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+
+    // Test case 3: Pop element from NULL list
+    CU_ASSERT_PTR_NULL(xList_popBack(NULL));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_remove(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+
+    // Test case 1: Remove element from empty list
+    CU_ASSERT_EQUAL(xList_remove(list, 0), NULL);
+
+    // Test case 2: Remove element from non-empty list
+    xUInt32 value = 0x12345678;
+    xList_pushBack(list, &value);
+    xUInt32 *removed = xList_remove(list, 0);
+    CU_ASSERT_EQUAL(*removed, value);
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+    free(removed);
+
+    // Test case 3: Remove element from NULL list
+    CU_ASSERT_PTR_NULL(xList_remove(NULL, 0));
+
+    // Test case 4: Remove element at invalid index
+    CU_ASSERT_PTR_NULL(xList_remove(list, 0));
+
+    // Cleanup
+    xList_free(list);
+}
+
+void test_xList_clear(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Clear empty list
+    xList_clear(list);
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+
+    // Test case 2: Clear non-empty list
+    for (xSize i = 0; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    xList_clear(list);
+    CU_ASSERT_EQUAL(xList_getSize(list), 0);
+
+    // Test case 3: Clear NULL list
+    xList_clear(NULL);  // should not crash
+
+    // Cleanup
+    xList_free(list);
+}
+
+int main(void)
+{
+    CU_pSuite pSuite = NULL;
+
+    // initialize CUnit test registry
+    if (CU_initialize_registry() != CUE_SUCCESS) {
+        return CU_get_error();
+    }
+
+    // add a suite to the registry
+    pSuite = CU_add_suite("xArray_test", NULL, NULL);
+    if (pSuite == NULL) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    // add the tests to the suite
+    if (CU_add_test(pSuite, "xList_new", test_xList_new) == NULL || CU_add_test(pSuite, "xList_free", test_xList_free) == NULL ||
+        CU_add_test(pSuite, "xList_getters", test_xList_getters) == NULL ||
+        CU_add_test(pSuite, "xList_pushFront", test_xList_pushFront) == NULL ||
+        CU_add_test(pSuite, "xList_pushBack", test_xList_pushBack) == NULL ||
+        CU_add_test(pSuite, "xList_insert", test_xList_insert) == NULL ||
+        CU_add_test(pSuite, "xList_peekFront", test_xList_peekFront) == NULL ||
+        CU_add_test(pSuite, "xList_peekBack", test_xList_peekBack) == NULL ||
+        CU_add_test(pSuite, "xList_get", test_xList_get) == NULL ||
+        CU_add_test(pSuite, "xList_popFront", test_xList_popFront) == NULL ||
+        CU_add_test(pSuite, "xList_popBack", test_xList_popBack) == NULL ||
+        CU_add_test(pSuite, "xList_remove", test_xList_remove) == NULL ||
+        CU_add_test(pSuite, "xList_clear", test_xList_clear) == NULL) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    // run all tests using the CUnit Basic interface
+    CU_basic_set_mode(CU_BRM_VERBOSE);
+    CU_basic_run_tests();
+    CU_cleanup_registry();
+
+    return CU_get_error();
+}


### PR DESCRIPTION
This pull request adds a new module, `xList.h`, which implements a generic linked list data structure in the `xStructures` module. The `xList` structure represents a linked list and provides functions for creating, manipulating, and freeing the list. The module also includes functions for inserting, getting, and removing elements at specified indices, as well as pushing and popping elements from the front and back of the list. Unit tests have been implemented for all functions, and the documentation in the header file has been updated accordingly.