### PR TITLE
Implemented `xQueue` as ready component of `xStructures` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ The "eXtra C Framework" includes a set of commonly used data structures and func
 - Mathematical matrix operations module (`xMatrix.h`)
 - Dynamic generic linked list implementation (`xList.h`)
 - Dynamic generic stack implementation (`xStack.h`)
+- Dynamic generic queue implementation (`xQueue.h`)
 ### Listed modules are tested and ready for use in projects
 
 ## Experimental modules (lacking tests, documentation or are incomplete):
 - Dynamic generic treemap implementation (`xDictionary.h`)
-- Dynamic generic queue implementation (`xQueue.h`)
 - Custom memory allocation module (`xAlloc.h`)
 ### These modules are available in respective `dev-X` branches, bugs and issues are expected until proper testing is done
 
 ## Planned modules (could be implemented in the future):
+- Ability to set underlying structures in higher complexity structures (e.g. queue and stack can use linked list or array as internal structure)
 - Hash table implementation
 - Priority queue implementation
 - File I/O module

--- a/include/xStructures/xList.h
+++ b/include/xStructures/xList.h
@@ -218,6 +218,21 @@ void *xList_peekBack(const xList *list);
  */
 void xList_clear(xList *list);
 
+/**
+ * @brief
+ * Copy list to new list.
+ * 
+ * @param list Pointer to the list object.
+ * @return Pointer to new list object with copied data.
+ *
+ * @note
+ * If function fails to allocate memory, it will return invalid xList object.
+ *
+ * @note
+ * Reference to data is copied, so changes to data in one object will affect other object.
+ */
+xList *xList_copy(const xList *list);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/xStructures/xQueue.h
+++ b/include/xStructures/xQueue.h
@@ -2,8 +2,8 @@
  * @file xQueue.h
  * @author 0xDontCare (https://github.com/0xDontCare)
  * @brief Queue implementation in xStructures module.
- * @version 0.1
- * @date 05.08.2024.
+ * @version 0.10
+ * @date 17.09.2024.
  *
  * Module declares dynamic queue structure along with funcitons for managing it. All functions have prefix `xQueue_`.
  */
@@ -19,19 +19,17 @@ extern "C" {
 
 typedef struct xQueue_s xQueue;
 
-xQueue xQueue_new(xSize elemSize);
+xQueue *xQueue_new(xSize elemSize);
 
 void xQueue_free(xQueue *queue);
 
-inline xSize xQueue_getSize(const xQueue *queue);
+extern xSize xQueue_getSize(const xQueue *queue);
 
-inline xSize xQueue_getCapacity(const xQueue *queue);
+extern xSize xQueue_getCapacity(const xQueue *queue);
 
-inline xSize xQueue_getElemSize(const xQueue *queue);
+extern xSize xQueue_getElemSize(const xQueue *queue);
 
-// inline const void *xQueue_getData(const xQueue *queue);
-
-inline xBool xQueue_isValid(const xQueue *queue);
+extern xBool xQueue_isValid(const xQueue *queue);
 
 void xQueue_enqueue(xQueue *queue, const void *data);
 
@@ -41,7 +39,7 @@ const void *xQueue_peek(const xQueue *queue);
 
 void xQueue_clear(xQueue *queue);
 
-xQueue xQueue_copy(const xQueue *queue);
+xQueue *xQueue_copy(const xQueue *queue);
 
 #ifdef __cplusplus
 }

--- a/include/xStructures/xQueue.h
+++ b/include/xStructures/xQueue.h
@@ -17,28 +17,137 @@
 extern "C" {
 #endif
 
+/**
+ * @brief
+ * Queue structure introduced by xcFramework.
+ *
+ * @note
+ * Do not access structure members directly. Use provided functions for managing xQueue object.
+ */
 typedef struct xQueue_s xQueue;
 
+/**
+ * @brief
+ * Create empty xQueue object.
+ *
+ * @param elemSize Size of single element in bytes.
+ * @return Pointer to xQueue object with no data.
+ *
+ * @note
+ * If function fails to allocate memory or `elemSize` is zero, returned object will be invalid to use. You can use xQueue_isValid()
+ * to check if created object is valid.
+ */
 xQueue *xQueue_new(xSize elemSize);
 
+/**
+ * @brief
+ * Free xQueue object and its data from memory.
+ *
+ * @param queue Pointer to xQueue object to free.
+ *
+ * @note
+ * Once xQueue object is freed, it is invalidated and no longer usable with other functions.
+ *
+ * @note
+ * All elements in the queue are freed as well. If they contain other dynamically allocated data, it should be freed by user before.
+ */
 void xQueue_free(xQueue *queue);
 
+/**
+ * @brief
+ * Get number of elements in queue.
+ *
+ * @param queue Pointer to xQueue object.
+ * @return xSize Number of elements in queue.
+ */
 extern xSize xQueue_getSize(const xQueue *queue);
 
 // extern xSize xQueue_getCapacity(const xQueue *queue);
 
+/**
+ * @brief
+ * Get size of single element in queue in bytes.
+ *
+ * @param queue Pointer to xQueue object.
+ * @return xSize Size of single element in queue in bytes.
+ */
 extern xSize xQueue_getElemSize(const xQueue *queue);
 
+/**
+ * @brief
+ * Check if xQueue object is valid.
+ *
+ * @param queue Pointer to xQueue object.
+ * @return xBool Non-zero if object is valid, zero otherwise.
+ */
 extern xBool xQueue_isValid(const xQueue *queue);
 
+/**
+ * @brief
+ * Enqueue data to the queue.
+ *
+ * @param queue Pointer to the queue object.
+ * @param data Pointer to data to enqueue.
+ *
+ * @note
+ * If data is NULL or queue is invalid, function will do nothing.
+ */
 void xQueue_enqueue(xQueue *queue, const void *data);
 
+/**
+ * @brief
+ * Dequeue data from the queue and return it.
+ *
+ * @param queue Pointer to the queue object.
+ * @return Pointer to dequeued data.
+ *
+ * @note
+ * If queue is invalid or empty, function will return NULL.
+ *
+ * @warning
+ * Caller is responsible for freeing returned data.
+ */
 void *xQueue_dequeue(xQueue *queue);
 
+/**
+ * @brief
+ * Peek data from the queue without removing it.
+ *
+ * @param queue Pointer to the queue object.
+ * @return const void* Pointer to peeked data.
+ *
+ * @note
+ * If queue is invalid or empty, function will return NULL.
+ *
+ * @warning
+ * Returned data should not be freed as it is not a copy. Trying to do so will result in undefined behavior.
+ */
 const void *xQueue_peek(const xQueue *queue);
 
+/**
+ * @brief
+ * Clear the queue.
+ *
+ * @param queue Pointer to the queue object.
+ *
+ * @note
+ * If element in the queue contain dynamically allocated data, it should be freed by user before calling this function.
+ */
 void xQueue_clear(xQueue *queue);
 
+/**
+ * @brief
+ * Create a copy of the queue.
+ *
+ * @param queue Pointer to the queue object.
+ * @return Pointer to the new queue object.
+ *
+ * @note
+ * If queue is invalid, function will return NULL.
+ *
+ * @note
+ * If elements in the queue contain dynamically allocated data, it should be freed by user before freeing the copied queue.
+ */
 xQueue *xQueue_copy(const xQueue *queue);
 
 #ifdef __cplusplus

--- a/include/xStructures/xQueue.h
+++ b/include/xStructures/xQueue.h
@@ -25,7 +25,7 @@ void xQueue_free(xQueue *queue);
 
 extern xSize xQueue_getSize(const xQueue *queue);
 
-extern xSize xQueue_getCapacity(const xQueue *queue);
+// extern xSize xQueue_getCapacity(const xQueue *queue);
 
 extern xSize xQueue_getElemSize(const xQueue *queue);
 

--- a/include/xStructures/xQueue.h
+++ b/include/xStructures/xQueue.h
@@ -1,0 +1,50 @@
+/**
+ * @file xQueue.h
+ * @author 0xDontCare (https://github.com/0xDontCare)
+ * @brief Queue implementation in xStructures module.
+ * @version 0.1
+ * @date 05.08.2024.
+ *
+ * Module declares dynamic queue structure along with funcitons for managing it. All functions have prefix `xQueue_`.
+ */
+
+#ifndef XSTRUCTURES_QUEUE_H
+#define XSTRUCTURES_QUEUE_H
+
+#include "xBase/xTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct xQueue_s xQueue;
+
+xQueue xQueue_new(xSize elemSize);
+
+void xQueue_free(xQueue *queue);
+
+inline xSize xQueue_getSize(const xQueue *queue);
+
+inline xSize xQueue_getCapacity(const xQueue *queue);
+
+inline xSize xQueue_getElemSize(const xQueue *queue);
+
+// inline const void *xQueue_getData(const xQueue *queue);
+
+inline xBool xQueue_isValid(const xQueue *queue);
+
+void xQueue_enqueue(xQueue *queue, const void *data);
+
+void *xQueue_dequeue(xQueue *queue);
+
+const void *xQueue_peek(const xQueue *queue);
+
+void xQueue_clear(xQueue *queue);
+
+xQueue xQueue_copy(const xQueue *queue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XSTRUCTURES_QUEUE_H

--- a/src/xStructures/xList.c
+++ b/src/xStructures/xList.c
@@ -311,3 +311,25 @@ void xList_clear(xList *list)
     list->tail = NULL;
     list->listSize = 0;
 }
+
+xList *xList_copy(const xList *list)
+{
+    // validate arguments
+    if (!xList_isValid(list)) {
+        return NULL;
+    }
+
+    // create new list and copy all elements
+    xList *newList = xList_new(list->elemSize);
+    if (!newList) {
+        return NULL;
+    }
+
+    xListNode *current = list->head;
+    while (current) {
+        xList_pushBack(newList, current->data);
+        current = current->next;
+    }
+
+    return newList;
+}

--- a/src/xStructures/xQueue.c
+++ b/src/xStructures/xQueue.c
@@ -111,6 +111,10 @@ xQueue *xQueue_copy(const xQueue *queue)
         return NULL;
     }
     newQueue->internalList = xList_copy(queue->internalList);
+    if (!xQueue_isValid(newQueue)) {
+        free(newQueue);
+        return NULL;
+    }
 
     return newQueue;
 }

--- a/src/xStructures/xQueue.c
+++ b/src/xStructures/xQueue.c
@@ -11,14 +11,21 @@ struct xQueue_s {
     xSize queueCapacity;
 };
 
-xQueue xQueue_new(xSize elemSize)
+xQueue *xQueue_new(xSize elemSize)
 {
     if (elemSize == 0) {
-        return (xQueue){0};
+        return NULL;
     }
 
-    xQueue queue = {0};
-    queue.elemSize = elemSize;
+    xQueue *queue = (xQueue *)malloc(sizeof(xQueue));
+    if (!queue) {
+        return NULL;
+    }
+
+    queue->elemSize = elemSize;
+    queue->queueSize = 0;
+    queue->queueCapacity = 0;
+    queue->data = NULL;
     return queue;
 }
 
@@ -41,7 +48,7 @@ inline xSize xQueue_getCapacity(const xQueue *queue) { return (queue) ? queue->q
 
 inline xSize xQueue_getElemSize(const xQueue *queue) { return (queue) ? queue->elemSize : 0; }
 
-inline xBool xQueue_isValid(const xQueue *queue) { return (queue && queue->data && queue->elemSize) ? true : false; }
+inline xBool xQueue_isValid(const xQueue *queue) { return (queue && queue->elemSize) ? true : false; }
 
 void xQueue_enqueue(xQueue *queue, const void *data)
 {
@@ -97,16 +104,16 @@ void xQueue_clear(xQueue *queue)
     queue->queueSize = 0;
 }
 
-xQueue xQueue_copy(const xQueue *queue)
+xQueue *xQueue_copy(const xQueue *queue)
 {
     if (!xQueue_isValid(queue)) {
         return xQueue_new(0);
     }
 
-    xQueue newQueue = xQueue_new(queue->elemSize);
-    if (xQueue_isValid(&newQueue)) {
+    xQueue *newQueue = xQueue_new(queue->elemSize);
+    if (xQueue_isValid(newQueue)) {
         for (xSize i = 0; i < queue->queueSize; i++) {
-            xQueue_enqueue(&newQueue, queue->data[i]);
+            xQueue_enqueue(newQueue, queue->data[i]);
         }
     }
 

--- a/src/xStructures/xQueue.c
+++ b/src/xStructures/xQueue.c
@@ -1,0 +1,114 @@
+#include "xStructures/xQueue.h"
+#include <stdlib.h>  // malloc, realloc, free
+#include "xBase/xTypes.h"
+
+// TODO: remove dependency on stdlib.h (custom memory allocation functions)
+
+struct xQueue_s {
+    void **data;
+    xSize elemSize;
+    xSize queueSize;
+    xSize queueCapacity;
+};
+
+xQueue xQueue_new(xSize elemSize)
+{
+    if (elemSize == 0) {
+        return (xQueue){0};
+    }
+
+    xQueue queue = {0};
+    queue.elemSize = elemSize;
+    return queue;
+}
+
+void xQueue_free(xQueue *queue)
+{
+    if (!queue || !queue->data) {
+        return;
+    }
+
+    free(queue->data);
+    queue->data = NULL;
+    queue->queueSize = 0;
+    queue->queueCapacity = 0;
+    queue->elemSize = 0;
+}
+
+inline xSize xQueue_getSize(const xQueue *queue) { return (queue) ? queue->queueSize : 0; }
+
+inline xSize xQueue_getCapacity(const xQueue *queue) { return (queue) ? queue->queueCapacity : 0; }
+
+inline xSize xQueue_getElemSize(const xQueue *queue) { return (queue) ? queue->elemSize : 0; }
+
+inline xBool xQueue_isValid(const xQueue *queue) { return (queue && queue->data && queue->elemSize) ? true : false; }
+
+void xQueue_enqueue(xQueue *queue, const void *data)
+{
+    if (!xQueue_isValid(queue) || !data) {
+        return;
+    }
+
+    if (queue->queueCapacity < queue->queueSize + 1) {
+        void **newData =
+            (void **)realloc(queue->data, ((queue->queueCapacity == 0) ? 1 : queue->queueCapacity * 2) * sizeof(void *));
+        if (!newData) {
+            return;
+        }
+
+        queue->data = newData;
+        queue->queueCapacity = (queue->queueCapacity == 0) ? 1 : queue->queueCapacity * 2;
+    }
+
+    queue->data[queue->queueSize] = (void *)data;
+    queue->queueSize++;
+}
+
+void *xQueue_dequeue(xQueue *queue)
+{
+    if (!xQueue_isValid(queue) || queue->queueSize == 0) {
+        return NULL;
+    }
+
+    void *ret = queue->data[0];
+    for (xSize i = 1; i < queue->queueSize; i++) {
+        queue->data[i - 1] = queue->data[i];
+    }
+
+    queue->queueSize--;
+    return ret;
+}
+
+const void *xQueue_peek(const xQueue *queue)
+{
+    if (!xQueue_isValid(queue) || queue->queueSize == 0) {
+        return NULL;
+    }
+
+    return (const void *)queue->data[0];
+}
+
+void xQueue_clear(xQueue *queue)
+{
+    for (xSize i = 0; i < queue->queueSize; i++) {
+        queue->data[i] = NULL;
+    }
+
+    queue->queueSize = 0;
+}
+
+xQueue xQueue_copy(const xQueue *queue)
+{
+    if (!xQueue_isValid(queue)) {
+        return xQueue_new(0);
+    }
+
+    xQueue newQueue = xQueue_new(queue->elemSize);
+    if (xQueue_isValid(&newQueue)) {
+        for (xSize i = 0; i < queue->queueSize; i++) {
+            xQueue_enqueue(&newQueue, queue->data[i]);
+        }
+    }
+
+    return newQueue;
+}

--- a/tests/xList_test.c
+++ b/tests/xList_test.c
@@ -335,6 +335,37 @@ void test_xList_clear(void)
     xList_free(list);
 }
 
+void test_xList_copy(void)
+{
+    xList *list = xList_new(sizeof(xUInt32));
+    xUInt32 values[] = {0x12345678, 0x9ABCDEF0, 0x13579BDF, 0x2468ACE0, 0x369BCEF0};
+
+    // Test case 1: Copy empty list
+    xList *copy = xList_copy(list);
+    CU_ASSERT_PTR_NOT_NULL(copy);
+    CU_ASSERT_EQUAL(xList_getSize(copy), 0);
+    xList_free(copy);
+
+    // Test case 2: Copy non-empty list
+    for (xSize i = 0; i < 5; i++) {
+        xList_pushBack(list, &values[i]);
+    }
+    copy = xList_copy(list);
+    CU_ASSERT_PTR_NOT_NULL(copy);
+    CU_ASSERT_EQUAL(xList_getSize(copy), 5);
+    for (xSize i = 0; i < 5; i++) {
+        CU_ASSERT_EQUAL(*(xUInt32 *)xList_get(copy, i), values[i]);
+    }
+    xList_free(copy);
+
+    // Test case 3: Copy NULL list
+    copy = xList_copy(NULL);
+    CU_ASSERT_PTR_NULL(copy);
+
+    // Cleanup
+    xList_free(list);
+}
+
 int main(void)
 {
     CU_pSuite pSuite = NULL;
@@ -363,7 +394,8 @@ int main(void)
         CU_add_test(pSuite, "xList_popFront", test_xList_popFront) == NULL ||
         CU_add_test(pSuite, "xList_popBack", test_xList_popBack) == NULL ||
         CU_add_test(pSuite, "xList_remove", test_xList_remove) == NULL ||
-        CU_add_test(pSuite, "xList_clear", test_xList_clear) == NULL) {
+        CU_add_test(pSuite, "xList_clear", test_xList_clear) == NULL ||
+        CU_add_test(pSuite, "xList_copy", test_xList_copy) == NULL) {
         CU_cleanup_registry();
         return CU_get_error();
     }

--- a/tests/xQueue_test.c
+++ b/tests/xQueue_test.c
@@ -177,7 +177,7 @@ void test_xQueue_copy(void)
 
     // Test case 1: Copy empty queue
     xQueue *copy = xQueue_copy(queue);
-    CU_ASSERT_PTR_NULL(copy);
+    CU_ASSERT_PTR_NOT_NULL(copy);
 
     // Test case 2: Copy non-empty queue
     for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {

--- a/tests/xQueue_test.c
+++ b/tests/xQueue_test.c
@@ -1,0 +1,242 @@
+/**
+ * @file xQueue_test.c
+ * @author 0xDontCare (you@domain.com)
+ * @brief CUnit test for xQueue module.
+ * @version 0.1
+ * @date 17.09.2024.
+ */
+
+#include <CUnit/Basic.h>
+#include <CUnit/CUnit.h>
+#include <CUnit/TestDB.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include "xBase/xTypes.h"
+#include "xStructures/xQueue.h"
+
+void test_xQueue_new(void)
+{
+    xQueue *queue = NULL;
+
+    // Test case 1: Valid queue element size
+    queue = xQueue_new(sizeof(xUInt32));
+    CU_ASSERT_PTR_NOT_NULL(queue);
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 0);
+    CU_ASSERT_EQUAL(xQueue_getElemSize(queue), sizeof(xUInt32));
+    CU_ASSERT_EQUAL(xQueue_isValid(queue), true);
+    xQueue_free(queue);
+
+    // Test case 2: Invalid queue element size
+    queue = xQueue_new(0);  // should return NULL
+    CU_ASSERT_PTR_NULL(queue);
+}
+
+void test_xQueue_free(void)
+{
+    // this test chould be analyzed through debugger and valgrind
+
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+
+    // Test case 1: Valid queue
+    xQueue_free(queue);
+
+    // Test case 2: NULL queue
+    xQueue_free(NULL);  // should not crash
+}
+
+void test_xQueue_getters(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Get size of empty queue
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 0);
+
+    // Test case 2: Get element size of queue
+    CU_ASSERT_EQUAL(xQueue_getElemSize(queue), sizeof(xUInt32));
+
+    // Test case 3: Get NULL queue size
+    CU_ASSERT_EQUAL(xQueue_getSize(NULL), 0);
+
+    // Test case 4: Get NULL queue element size
+    CU_ASSERT_EQUAL(xQueue_getElemSize(NULL), 0);
+
+    // Test case 5: Get size of non-empty queue
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), sizeof(values) / sizeof(values[0]));
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+void test_xQueue_enqueue(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Enqueue to empty queue
+    xQueue_enqueue(queue, &values[0]);
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 1);
+
+    // Test case 2: Enqueue to non-empty queue
+    for (xSize i = 1; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), sizeof(values) / sizeof(values[0]));
+
+    // Test case 3: Enqueue to NULL queue
+    xQueue_enqueue(NULL, &values[0]);  // should not crash
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+void test_xQueue_dequeue(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Dequeue from empty queue
+    CU_ASSERT_PTR_NULL(xQueue_dequeue(queue));
+
+    // Test case 2: Dequeue from non-empty queue
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xUInt32 *value = (xUInt32 *)xQueue_dequeue(queue);
+        CU_ASSERT_PTR_NOT_NULL(value);
+        CU_ASSERT_EQUAL(*value, values[i]);
+        free(value);
+    }
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 0);
+
+    // Test case 3: Dequeue from NULL queue
+    CU_ASSERT_PTR_NULL(xQueue_dequeue(NULL));
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+void test_xQueue_peek(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Peek from empty queue
+    CU_ASSERT_PTR_NULL(xQueue_peek(queue));
+
+    // Test case 2: Peek from non-empty queue
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), sizeof(values) / sizeof(values[0]));
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xUInt32 *value = (xUInt32 *)xQueue_peek(queue);
+        CU_ASSERT_PTR_NOT_NULL(value);
+        CU_ASSERT_EQUAL(*value, values[i]);
+        free(xQueue_dequeue(queue));
+    }
+
+    // Test case 3: Peek from NULL queue
+    CU_ASSERT_PTR_NULL(xQueue_peek(NULL));
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+void test_xQueue_clear(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Clear empty queue
+    xQueue_clear(queue);
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 0);
+
+    // Test case 2: Clear non-empty queue
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    xQueue_clear(queue);
+    CU_ASSERT_EQUAL(xQueue_getSize(queue), 0);
+
+    // Test case 3: Clear NULL queue
+    xQueue_clear(NULL);  // should not crash
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+void test_xQueue_copy(void)
+{
+    xQueue *queue = xQueue_new(sizeof(xUInt32));
+    xUInt32 values[] = {1, 2, 3, 4, 5};
+
+    // Test case 1: Copy empty queue
+    xQueue *copy = xQueue_copy(queue);
+    CU_ASSERT_PTR_NULL(copy);
+
+    // Test case 2: Copy non-empty queue
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xQueue_enqueue(queue, &values[i]);
+    }
+    copy = xQueue_copy(queue);
+    CU_ASSERT_PTR_NOT_NULL(copy);
+    CU_ASSERT_EQUAL(xQueue_getSize(copy), xQueue_getSize(queue));
+    CU_ASSERT_EQUAL(xQueue_getElemSize(copy), xQueue_getElemSize(queue));
+    CU_ASSERT_EQUAL(xQueue_isValid(copy), true);
+    for (xSize i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+        xUInt32 *value = (xUInt32 *)xQueue_dequeue(copy);
+        CU_ASSERT_PTR_NOT_NULL(value);
+        CU_ASSERT_EQUAL(*value, values[i]);
+        free(value);
+    }
+    xQueue_free(copy);
+
+    // Test case 3: Copy NULL queue
+    copy = xQueue_copy(NULL);
+    CU_ASSERT_PTR_NULL(copy);
+
+    // Cleanup
+    xQueue_free(queue);
+}
+
+int main(void)
+{
+    CU_pSuite pSuite = NULL;
+
+    // Initialize the CUnit test registry
+    if (CU_initialize_registry() != CUE_SUCCESS) {
+        return CU_get_error();
+    }
+
+    // Add a suite to the registry
+    pSuite = CU_add_suite("xQueue_test", NULL, NULL);
+    if (pSuite == NULL) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    // Add the tests to the suite
+    if (CU_add_test(pSuite, "test_xQueue_new", test_xQueue_new) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_free", test_xQueue_free) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_getters", test_xQueue_getters) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_enqueue", test_xQueue_enqueue) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_dequeue", test_xQueue_dequeue) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_peek", test_xQueue_peek) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_clear", test_xQueue_clear) == NULL ||
+        CU_add_test(pSuite, "test_xQueue_copy", test_xQueue_copy) == NULL) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    // Run all tests using the CUnit Basic interface
+    CU_basic_set_mode(CU_BRM_VERBOSE);
+    CU_basic_run_tests();
+    CU_cleanup_registry();
+
+    return CU_get_error();
+}


### PR DESCRIPTION
xQueue has been implemented as wrapper structure based around xList (linked list data structure).

Additionally a copy function has been added to `xList` module for ability to create copy of list, following all other structures implemented up until now.