### PR TITLE
Add in-place matrix operations and flatten/unflatten functions

### DIFF
--- a/include/xLinear/xMatrix.h
+++ b/include/xLinear/xMatrix.h
@@ -2,8 +2,8 @@
  * @file xMatrix.h
  * @author 0xDontCare (https://github.com/0xDontCare)
  * @brief Matrix structure and functions.
- * @version 0.10
- * @date 26.07.2024.
+ * @version 0.11
+ * @date 04.10.2024.
  *
  * Module declares matrix structure and mathematical operations applicable to them. All functions have prefix `xMatrix_`.
  */

--- a/include/xLinear/xMatrix.h
+++ b/include/xLinear/xMatrix.h
@@ -471,6 +471,42 @@ xMatrix *xMatrix_map2(const xMatrix *lhs, const xMatrix *rhs, float (*func)(floa
  */
 xMatrix *xMatrix_mapScalar(const xMatrix *matrix, float scalar, float (*func)(float, float));
 
+/**
+ * @brief
+ * Flatten matrix to contiguous array.
+ *
+ * @param matrix Pointer to xMatrix object.
+ * @return Array of floats containing all matrix elements in row-major order.
+ *
+ * @note
+ * If matrix is invalid or array allocation fails, NULL is returned.
+ *
+ * @note
+ * Returned array should be freed using free() function.
+ *
+ * @note
+ * Flattened array size is equal to number of rows multiplied by number of columns of input matrix.
+ */
+float *xMatrix_flatten(const xMatrix *matrix);
+
+/**
+ * @brief
+ * Unflatten contiguous array to matrix.
+ *
+ * @param data Pointer to row-major array of floats.
+ * @param rows Number of rows.
+ * @param cols Number of columns.
+ * @return Pointer to xMatrix object created from array data.
+ *
+ * @note
+ * If array is NULL or allocation fails, NULL is returned.
+ *
+ * @warning
+ * Array length should be equal to product of `rows` and `cols`. Otherwise, behaviour is undefined and could likely lead to memory
+ * access violation.
+ */
+xMatrix *xMatrix_unflatten(const float *data, xSize rows, xSize cols);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/include/xLinear/xMatrix.h
+++ b/include/xLinear/xMatrix.h
@@ -149,6 +149,18 @@ xMatrix *xMatrix_transpose(const xMatrix *matrix);
 
 /**
  * @brief
+ * Perform in-place matrix transposition.
+ *
+ * @param matrix Pointer to xMatrix object.
+ * @return Passthrough pointer to matrix from input.
+ *
+ * @note
+ * If passed matrix is invalid, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_transpose_inplace(xMatrix *matrix);
+
+/**
+ * @brief
  * Add two matrices.
  *
  * @param lhs Left-hand side matrix.
@@ -159,6 +171,20 @@ xMatrix *xMatrix_transpose(const xMatrix *matrix);
  * If either of passed matrices are invalid or they don't have same dimensions, NULL is returned.
  */
 xMatrix *xMatrix_add(const xMatrix *lhs, const xMatrix *rhs);
+
+/**
+ * @brief
+ * Add two matrices and store result in third matrix without allocating new matrix.
+ *
+ * @param res Matrix to store result in.
+ * @param lhs Left-hand side matrix.
+ * @param rhs Right-hand side matrix.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If either of passed matrices are invalid or they don't have same dimensions, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_add_inplace(xMatrix *res, const xMatrix *lhs, const xMatrix *rhs);
 
 /**
  * @brief
@@ -175,6 +201,20 @@ xMatrix *xMatrix_sub(const xMatrix *lhs, const xMatrix *rhs);
 
 /**
  * @brief
+ * Subtract two matrices and store result in third matrix without allocating new matrix.
+ *
+ * @param res Matrix to store result in.
+ * @param lhs Left-hand side matrix.
+ * @param rhs Right-hand side matrix.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If either of passed matrices are invalid or they don't have same dimensions, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_sub_inplace(xMatrix *res, const xMatrix *lhs, const xMatrix *rhs);
+
+/**
+ * @brief
  * Multiply two matrices.
  *
  * @param lhs Left-hand side matrix.
@@ -182,9 +222,23 @@ xMatrix *xMatrix_sub(const xMatrix *lhs, const xMatrix *rhs);
  * @return Pointer to xMatrix object containing matrix product of two matrices.
  *
  * @note
- * If either of passed matrices is invalid or they have incompatible dimensions, NULL is returned.
+ * If either of passed matrices are invalid or they have incompatible dimensions, NULL is returned.
  */
 xMatrix *xMatrix_mul(const xMatrix *lhs, const xMatrix *rhs);
+
+/**
+ * @brief
+ * Multiply two matrices and store result in third matrix without allocating new matrix.
+ *
+ * @param res Matrix to store result in.
+ * @param lhs Left-hand side matrix.
+ * @param rhs Right-hand side matrix.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If either of passed matrices are invalid or they have incompatible dimensions, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_mul_inplace(xMatrix *res, const xMatrix *lhs, const xMatrix *rhs);
 
 /**
  * @brief
@@ -204,6 +258,23 @@ xMatrix *xMatrix_dotmul(const xMatrix *lhs, const xMatrix *rhs);
 
 /**
  * @brief
+ * Calculate Hadamard product of two matrices and store result in third matrix without allocating new matrix.
+ *
+ * @param res Matrix to store result in.
+ * @param lhs Left-hand side matrix.
+ * @param rhs Right-hand side matrix.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If either of passed matrices are invalid or they don't have same dimensions, no operation is performed and NULL is returned.
+ *
+ * @note
+ * Hadamard product is element-wise multiplication of two matrices.
+ */
+xMatrix *xMatrix_dotmul_inplace(xMatrix *res, const xMatrix *lhs, const xMatrix *rhs);
+
+/**
+ * @brief
  * Add scalar to matrix.
  *
  * @param matrix Pointer to xMatrix object.
@@ -214,6 +285,20 @@ xMatrix *xMatrix_dotmul(const xMatrix *lhs, const xMatrix *rhs);
  * If passed matrix is invalid, NULL is returned.
  */
 xMatrix *xMatrix_scalarAdd(const xMatrix *matrix, float scalar);
+
+/**
+ * @brief
+ * Add scalar to matrix and store result in third matrix without allocating new matrix.
+ *
+ * @param res Pointer to xMatrix object to store result in.
+ * @param matrix Pointer to xMatrix object.
+ * @param scalar Scalar value to add to each element.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If passed matrix is invalid, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_scalarAdd_inplace(xMatrix *res, const xMatrix *matrix, float scalar);
 
 /**
  * @brief
@@ -230,6 +315,20 @@ xMatrix *xMatrix_scalarSub(const xMatrix *matrix, float scalar);
 
 /**
  * @brief
+ * Subtract scalar from matrix and store result in third matrix without allocating new matrix.
+ *
+ * @param res Pointer to xMatrix object to store result in.
+ * @param matrix Pointer to xMatrix object.
+ * @param scalar Scalar value to subtract from each element.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If passed matrix is invalid, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_scalarSub_inplace(xMatrix *res, const xMatrix *matrix, float scalar);
+
+/**
+ * @brief
  * Multiply matrix by scalar.
  *
  * @param matrix Pointer to xMatrix object.
@@ -240,6 +339,20 @@ xMatrix *xMatrix_scalarMul(const xMatrix *matrix, float scalar);
 
 /**
  * @brief
+ * Multiply matrix by scalar and store result in third matrix without allocating new matrix.
+ *
+ * @param res Pointer to xMatrix object to store result in.
+ * @param matrix Pointer to xMatrix object.
+ * @param scalar Scalar value to multiply each element by.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If passed matrix is invalid, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_scalarMul_inplace(xMatrix *res, const xMatrix *matrix, float scalar);
+
+/**
+ * @brief
  * Divide matrix by scalar.
  *
  * @param matrix Pointer to xMatrix object.
@@ -247,6 +360,20 @@ xMatrix *xMatrix_scalarMul(const xMatrix *matrix, float scalar);
  * @return Pointer to xMatrix object containing matrix scaled by reciprocal of scalar.
  */
 xMatrix *xMatrix_scalarDiv(const xMatrix *matrix, float scalar);
+
+/**
+ * @brief
+ * Divide matrix by scalar and store result in third matrix without allocating new matrix.
+ *
+ * @param res Pointer to xMatrix object to store result in.
+ * @param matrix Pointer to xMatrix object.
+ * @param scalar Scalar value to divide each element by.
+ * @return Passthrough pointer to res matrix.
+ *
+ * @note
+ * If passed matrix is invalid, no operation is performed and NULL is returned.
+ */
+xMatrix *xMatrix_scalarDiv_inplace(xMatrix *res, const xMatrix *matrix, float scalar);
 
 /**
  * @brief

--- a/src/xLinear/xMatrix.c
+++ b/src/xLinear/xMatrix.c
@@ -17,32 +17,35 @@ xMatrix *xMatrix_new(xSize rows, xSize cols)
         return NULL;
     }
 
-    // create matrix object
-    xMatrix *mat = (xMatrix *)malloc(sizeof(xMatrix));
+    // create matrix object and allocate memory for data
+    xMatrix *mat = (xMatrix *)malloc(sizeof(xMatrix) + rows * cols * sizeof(float));
     if (!mat) {
         return NULL;
     }
-    mat->data = (float *)calloc(rows * cols, sizeof(float));
-    if (!mat->data) {
-        free(mat);
-        return NULL;
-    }
+
+    mat->data = (float *)(mat + 1);
     mat->rows = rows;
     mat->cols = cols;
+
+    // zero-initialize matrix data
+    for (xSize i = 0; i < rows * cols; i++) {
+        mat->data[i] = 0.0f;
+    }
 
     return mat;
 }
 
 void xMatrix_free(xMatrix *matrix)
 {
+    // validate arguments
     if (!matrix) {
         return;
     }
 
-    if (matrix->data) {
-        free(matrix->data);
-        matrix->data = NULL;
-    }
+    // set matrix attributes to zero (invalidate matrix)
+    matrix->data = NULL;
+    matrix->rows = 0;
+    matrix->cols = 0;
 
     free(matrix);
 }

--- a/src/xLinear/xMatrix.c
+++ b/src/xLinear/xMatrix.c
@@ -608,3 +608,49 @@ xMatrix *xMatrix_mapScalar(const xMatrix *matrix, float scalar, float (*func)(fl
 
     return mat;
 }
+
+float *xMatrix_flatten(const xMatrix *matrix)
+{
+    // validate arguments
+    if (!xMatrix_isValid(matrix)) {
+        return NULL;
+    }
+
+    // create array to store flattened matrix
+    float *arr = (float *)malloc(matrix->rows * matrix->cols * sizeof(float));
+    if (!arr) {
+        return NULL;
+    }
+
+    // copy data
+    for (xSize i = 0; i < matrix->rows; i++) {
+        for (xSize j = 0; j < matrix->cols; j++) {
+            arr[i * matrix->cols + j] = xMatrix_get(matrix, i, j);
+        }
+    }
+
+    return arr;
+}
+
+xMatrix *xMatrix_unflatten(const float *arr, xSize rows, xSize cols)
+{
+    // validate arguments
+    if (!arr || !rows || !cols) {
+        return NULL;
+    }
+
+    // create matrix to store unflattened array
+    xMatrix *mat = xMatrix_new(rows, cols);
+    if (!xMatrix_isValid(mat)) {
+        return NULL;
+    }
+
+    // copy data
+    for (xSize i = 0; i < rows; i++) {
+        for (xSize j = 0; j < cols; j++) {
+            xMatrix_set(mat, i, j, arr[i * cols + j]);
+        }
+    }
+
+    return mat;
+}

--- a/tests/xMatrix_test.c
+++ b/tests/xMatrix_test.c
@@ -9,6 +9,7 @@
 #include <CUnit/Basic.h>
 #include <CUnit/CUnit.h>
 #include <CUnit/TestDB.h>
+#include <malloc.h>
 #include <math.h>
 #include "xBase/xTypes.h"
 #include "xLinear/xMatrix.h"
@@ -828,6 +829,48 @@ void test_xMatrix_mapScalar(void)
     xMatrix_free(mapped);
 }
 
+void test_xMatrix_flatten(void)
+{
+    // Test case 1: Flattening NULL matrix
+    xMatrix *mat = NULL;
+    float *flat = xMatrix_flatten(mat);
+    CU_ASSERT_PTR_NULL(flat);
+
+    // Test case 2: Flattening valid matrix
+    mat = xMatrix_new(3, 3);
+    xMatrix_fill(mat, 1.0f);
+    flat = xMatrix_flatten(mat);
+    CU_ASSERT_PTR_NOT_NULL(flat);
+    for (xSize i = 0; i < xMatrix_getRows(mat) * xMatrix_getCols(mat); i++) {
+        CU_ASSERT_EQUAL(flat[i], 1.0f);
+    }
+    xMatrix_free(mat);
+    free(flat);
+}
+
+void test_xMatrix_unflatten(void)
+{
+    // test case arrays
+    float *arr1 = NULL;
+    float arr2[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+    xMatrix *mat = NULL;
+
+    // Test case 1: Unflattening NULL array
+    mat = xMatrix_unflatten(arr1, 3, 3);
+    CU_ASSERT_PTR_NULL(mat);
+
+    // Test case 2: Unflattening valid array
+    mat = xMatrix_unflatten(arr2, 3, 3);
+    CU_ASSERT_PTR_NOT_NULL(mat);
+    CU_ASSERT_TRUE(xMatrix_isValid(mat));
+    for (xSize i = 0; i < xMatrix_getRows(mat); i++) {
+        for (xSize j = 0; j < xMatrix_getCols(mat); j++) {
+            CU_ASSERT_EQUAL(xMatrix_get(mat, i, j), arr2[i * 3 + j]);
+        }
+    }
+    xMatrix_free(mat);
+}
+
 int main(void)
 {
     CU_pSuite suite = NULL;
@@ -866,7 +909,9 @@ int main(void)
         (CU_add_test(suite, "xMatrix_minor", test_xMatrix_minor) == NULL) ||
         (CU_add_test(suite, "xMatrix_map", test_xMatrix_map) == NULL) ||
         (CU_add_test(suite, "xMatrix_map2", test_xMatrix_map2) == NULL) ||
-        (CU_add_test(suite, "xMatrix_mapScalar", test_xMatrix_mapScalar) == NULL)) {
+        (CU_add_test(suite, "xMatrix_mapScalar", test_xMatrix_mapScalar) == NULL) ||
+        (CU_add_test(suite, "xMatrix_flatten", test_xMatrix_flatten) == NULL) ||
+        (CU_add_test(suite, "xMatrix_unflatten", test_xMatrix_unflatten) == NULL)) {
         CU_cleanup_registry();
         return CU_get_error();
     }

--- a/tests/xMatrix_test.c
+++ b/tests/xMatrix_test.c
@@ -2,8 +2,8 @@
  * @file xMatrix_test.c
  * @author 0xDontCare (https://www.github.com/0xDontCare)
  * @brief CUnit test for all functions within xMatrix module.
- * @version 0.1
- * @date 14.09.2024.
+ * @version 0.2
+ * @date 04.10.2024.
  */
 
 #include <CUnit/Basic.h>


### PR DESCRIPTION
This pull request adds in-place equivalents to basic matrix operations, such as matrix addition, subtraction, multiplication, and similar. Previous functions for those operations which additionally allocate new matrix have been made to delegate work to these new functions. 
The pull also includes functions to convert a matrix to a flattened array and to unflatten a flattened array back into a matrix.
Tests have been added to ensure the correctness of the flattening and unflattening functions.
Additionally, the matrix data is now allocated contiguously with the descriptor to improve data locality and reduce number of individual allocations.